### PR TITLE
only override the user config if a linter is detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Use your favorite plugin manager.
   1. Add `Plug 'benjaminparnell/vim-switchblade'` to .vimrc
   2. Run `:PlugInstall`
 
+Default Linter
+==============
+
+Set your syntastic linter as normal, this will be used when no javascript linter config is detected by this plugin.
+
+e.g. with vim-plug:
+
+```
+let g:syntastic_javascript_checkers = ['standard']
+Plug 'benjaminparnell/vim-switchblade'
+```
+
 License
 -------
 

--- a/autoload/switchblade.vim
+++ b/autoload/switchblade.vim
@@ -5,8 +5,15 @@ let switchblade#linters = [
 \]
 
 function! switchblade#initialize(root)
-  let checkers = map(copy(g:switchblade#linters), 's:check(v:val)')
-  let g:syntastic_javascript_checkers = checkers
+  let checkers = []
+  for checker in map(copy(g:switchblade#linters), 's:check(v:val)')
+    if type(checker)
+      call add(checkers, checker)
+    endif
+  endfor
+  if len(checkers)
+    let g:syntastic_javascript_checkers = checkers
+  endif
 endfunction
 
 function! s:check(checker)


### PR DESCRIPTION
I've tweaked this so that it only sets `g:syntastic_javascript_checkers` if a linter config has been found. This then allows whatever you have set in your vimrc to remain untouched, meaning that you can now have a default linter.

This also cleans up the `checkers` array as it would set something like `[0, 'jshint', 0]` when a single linter was detected.
